### PR TITLE
Add macOS ad-hoc code signing after binary patching

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Claude Code's companion system generates your pet's visual traits (species, rari
 
 1. **You pick** your desired species, rarity, eyes, and hat through an interactive TUI
 2. **Brute-force search** finds a replacement salt string that produces your chosen pet when combined with your real user ID (typically takes <100ms)
-3. **Binary patch** replaces the salt in the compiled Claude Code ELF binary (all 3 occurrences) using an atomic rename, with a backup created first
+3. **Binary patch** replaces the salt in the compiled Claude Code binary (all 3 occurrences) using an atomic rename, with a backup created first
 4. **Auto-repair hook** (optional) installs a `SessionStart` hook in `~/.claude/settings.json` that re-applies the patch after Claude Code updates
 
 The patch is safe — it uses `rename()` to atomically swap the binary, which is the same technique package managers use. A running Claude session continues using the old binary in memory; the new pet appears on next launch.
@@ -229,7 +229,7 @@ The hook adds negligible startup time (~50ms) when no patch is needed.
 
 ## How the binary patch works
 
-Claude Code is a compiled Bun ELF binary at `~/.local/share/claude/versions/<version>`. The salt string `"friend-2026-401"` appears exactly 3 times:
+Claude Code is a compiled Bun binary (ELF on Linux, Mach-O on macOS) at `~/.local/share/claude/versions/<version>` (Linux) or the path shown by `which claude`. The salt string `"friend-2026-401"` appears exactly 3 times:
 - 2 occurrences in the bundled JavaScript code sections
 - 1 occurrence in a string table / data section
 
@@ -239,6 +239,7 @@ The patch:
 3. Replaces each with the new salt (always exactly 15 characters — same length, no byte offset shifts)
 4. Writes to a temp file, then atomically renames it over the original
 5. Verifies by re-reading
+6. On macOS, re-signs the binary with an ad-hoc signature (`codesign --force --sign -`)
 
 The atomic rename (`rename()` syscall) is safe even while Claude Code is running — the OS keeps the old inode open for any running process. The new binary takes effect on next launch.
 
@@ -264,7 +265,7 @@ This patches the salt back to the original, removes the SessionStart hook, and c
 
 ## Limitations
 
-- **Tested on Linux and macOS** — Windows should work but is not yet tested. Please [open an issue](https://github.com/cpaczek/any-buddy/issues) if you hit problems
+- **Tested on Linux and macOS** — on macOS, the binary is automatically ad-hoc re-signed after patching to avoid code signature invalidation. Windows should work but is not yet tested. Please [open an issue](https://github.com/cpaczek/any-buddy/issues) if you hit problems
 - **Requires Bun** — needed for matching Claude Code's wyhash implementation
 - **Salt string dependent** — if Anthropic changes the salt from `friend-2026-401` in a future version, the patch logic would need updating (but the tool will detect this and warn you)
 - **Stats partially selectable** — you can pick which stat is highest (peak) and lowest (dump), but not exact values

--- a/lib/patcher.mjs
+++ b/lib/patcher.mjs
@@ -175,6 +175,20 @@ export function isClaudeRunning(binaryPath) {
   }
 }
 
+// Ad-hoc codesign on macOS (required after patching Mach-O binaries)
+function codesignBinary(binaryPath) {
+  if (!IS_MAC) return { signed: false, error: null };
+  try {
+    execSync(`codesign --force --sign - "${binaryPath}"`, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 30000,
+    });
+    return { signed: true, error: null };
+  } catch (err) {
+    return { signed: false, error: err.message };
+  }
+}
+
 // Patch the binary: replace oldSalt with newSalt at all occurrences.
 export function patchBinary(binaryPath, oldSalt, newSalt) {
   if (oldSalt.length !== newSalt.length) {
@@ -239,10 +253,16 @@ export function patchBinary(binaryPath, oldSalt, newSalt) {
   // Verify
   const verifyBuf = readFileSync(binaryPath);
   const verify = findAllOccurrences(verifyBuf, newSalt);
+
+  // Re-sign on macOS (patching invalidates the Mach-O code signature)
+  const cs = codesignBinary(binaryPath);
+
   return {
     replacements: offsets.length,
     verified: verify.length === offsets.length,
     backupPath,
+    codesigned: cs.signed,
+    codesignError: cs.error,
   };
 }
 

--- a/lib/preflight.mjs
+++ b/lib/preflight.mjs
@@ -121,9 +121,8 @@ export function runPreflight({ requireBinary = true } = {}) {
         );
       } else if (plat === 'darwin') {
         warnings.push(
-          'macOS support is experimental.\n' +
-          '  If the binary is code-signed, patching may invalidate the signature.\n' +
-          '  If Claude Code won\'t launch after patching, run `any-buddy restore`.\n' +
+          'macOS: the binary will be ad-hoc re-signed after patching.\n' +
+          '  If Claude Code won\'t launch, run `any-buddy restore`.\n' +
           '  Please report issues at: ' + ISSUE_URL
         );
       }

--- a/lib/tui.mjs
+++ b/lib/tui.mjs
@@ -66,6 +66,13 @@ function showPet(bones, label = 'Your pet') {
   console.log();
 }
 
+function warnCodesign(result, binaryPath) {
+  if (result.codesignError) {
+    console.log(chalk.yellow(`  Warning: codesign failed: ${result.codesignError}`));
+    console.log(chalk.yellow(`  Run manually: codesign --force --sign - "${binaryPath}"`));
+  }
+}
+
 // ─── Subcommands ───
 
 export async function runCurrent() {
@@ -137,7 +144,10 @@ export async function runApply({ silent = false } = {}) {
       const prevCheck = verifySalt(binaryPath, config.previousSalt);
       if (prevCheck.found >= 3) {
         const result = patchBinary(binaryPath, config.previousSalt, config.salt);
-        if (!silent) console.log(chalk.green(`  Re-patched (${result.replacements} replacements).`));
+        if (!silent) {
+          console.log(chalk.green(`  Re-patched (${result.replacements} replacements).`));
+          warnCodesign(result, binaryPath);
+        }
         return;
       }
     }
@@ -145,7 +155,10 @@ export async function runApply({ silent = false } = {}) {
     const origCheck = verifySalt(binaryPath, ORIGINAL_SALT);
     if (origCheck.found >= 3) {
       const result = patchBinary(binaryPath, ORIGINAL_SALT, config.salt);
-      if (!silent) console.log(chalk.green(`  Patched after update (${result.replacements} replacements).`));
+      if (!silent) {
+        console.log(chalk.green(`  Patched after update (${result.replacements} replacements).`));
+        warnCodesign(result, binaryPath);
+      }
       return;
     }
     if (!silent) console.error('Could not find known salt in binary. Claude Code may have changed the salt string.');
@@ -155,6 +168,7 @@ export async function runApply({ silent = false } = {}) {
   const result = patchBinary(binaryPath, oldSalt, config.salt);
   if (!silent) {
     console.log(chalk.green(`  Applied (${result.replacements} replacements).`));
+    warnCodesign(result, binaryPath);
     if (isClaudeRunning(binaryPath)) {
       console.log(chalk.yellow('  Restart Claude Code for the change to take effect.'));
     }
@@ -170,8 +184,9 @@ export async function runRestore() {
     // Try to patch back to original
     const check = verifySalt(binaryPath, config.salt);
     if (check.found >= 3) {
-      patchBinary(binaryPath, config.salt, ORIGINAL_SALT);
+      const restoreResult = patchBinary(binaryPath, config.salt, ORIGINAL_SALT);
       console.log(chalk.green('  Restored original pet salt.'));
+      warnCodesign(restoreResult, binaryPath);
     } else {
       // Try backup
       try {
@@ -364,6 +379,11 @@ export async function runInteractive(flags = {}) {
 
   const patchResult = patchBinary(binaryPath, oldSalt, result.salt);
   console.log(chalk.green(`  Patched! ${patchResult.replacements} replacements, verified: ${patchResult.verified}`));
+  if (patchResult.codesigned) {
+    console.log(chalk.dim(`  Re-signed for macOS.`));
+  } else {
+    warnCodesign(patchResult, binaryPath);
+  }
   console.log(chalk.dim(`  Backup: ${patchResult.backupPath}`));
 
   // Save config


### PR DESCRIPTION
## Summary

- Adds automatic ad-hoc re-signing (`codesign --force --sign -`) after every binary patch on macOS
- Fixes the issue where patching the Mach-O binary invalidates its code signature, causing the kernel to kill the process on launch
- Works in all code paths: interactive patching, silent apply (SessionStart hook), and restore-via-repatch
- Surfaces codesign status to the user — shows success in interactive mode, prints manual fallback command if codesign fails
- Updates the macOS preflight warning from "experimental" to informational
- Fixes ELF-only terminology in README to be platform-accurate

## Changes

| File | What changed |
|---|---|
| `lib/patcher.mjs` | New `codesignBinary()` helper called at end of `patchBinary()` |
| `lib/tui.mjs` | New `warnCodesign()` helper; codesign feedback at all 5 `patchBinary` call sites |
| `lib/preflight.mjs` | Updated macOS warning text |
| `README.md` | Fixed "ELF binary" refs; added codesign step to patch docs; updated limitations |

## Design decisions

- **Codesign inside `patchBinary()`** — single point of change, all callers get it automatically
- **Never throws** — codesign failure is reported but doesn't block the patch result
- **No-op on non-Mac** — zero overhead on Linux/Windows
- **`restoreBinary()` untouched** — it restores the original backup with its intact signature

## Test plan

- [ ] On macOS: run interactive flow — binary should be patched AND signed
- [ ] Verify with `codesign -v <binary-path>`
- [ ] Launch `claude` — should not be killed
- [ ] Test `apply --silent` — should re-patch and re-sign after update
- [ ] Test `restore` — should restore original binary
- [ ] On Linux: verify no behavioral change (codesign is a no-op)