### PR TITLE
Fix Windows binary resolution for npm global installs

### DIFF
--- a/lib/patcher.mjs
+++ b/lib/patcher.mjs
@@ -60,6 +60,12 @@ export function findClaudeBinary() {
       // Try to find the actual binary in the same package.
       const fromPkg = resolveFromPackageDir(resolved);
       if (fromPkg) return fromPkg;
+
+      if (IS_WIN && !resolved.endsWith('.cmd')) {
+        const target = resolveWindowsShim(resolved + '.cmd');
+        if (target) return target;
+      }
+
       // Fall through to platform-specific candidates.
     } catch {
       // Can't stat — return it anyway, preflight will catch issues.
@@ -103,7 +109,7 @@ function getPlatformCandidates() {
     return [
       join(localAppData, 'Programs', 'claude', 'claude.exe'),
       join(appData, 'npm', 'claude.cmd'),
-      join(appData, 'npm', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.mjs'),
+      join(appData, 'npm', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js'),
       join(home, '.volta', 'bin', 'claude.exe'),
     ];
   }
@@ -215,7 +221,7 @@ function findAllOccurrences(buffer, searchStr) {
 export function getCurrentSalt(binaryPath) {
   const buf = readFileSync(binaryPath);
   const origOffsets = findAllOccurrences(buf, ORIGINAL_SALT);
-  if (origOffsets.length >= 3) {
+  if (origOffsets.length >= 1) {
     return { salt: ORIGINAL_SALT, patched: false, offsets: origOffsets };
   }
   return { salt: null, patched: true, offsets: origOffsets };

--- a/lib/preflight.mjs
+++ b/lib/preflight.mjs
@@ -71,7 +71,7 @@ export function runPreflight({ requireBinary = true } = {}) {
           const petConfig = loadPetConfig();
           if (petConfig?.salt) {
             const patchedResult = verifySalt(binaryPath, petConfig.salt);
-            if (patchedResult.found >= 2) {
+            if (patchedResult.found >= 1) {
               // Already patched by us — that's fine, we can re-patch
               saltCount = patchedResult.found;
               warnings.push(
@@ -98,9 +98,9 @@ export function runPreflight({ requireBinary = true } = {}) {
               `\n  Please report this at: ${ISSUE_URL}`
             );
           }
-        } else if (saltCount < 2) {
+        } else if (platform() !== 'win32' && saltCount < 3) {
           warnings.push(
-            `Salt found only ${saltCount} time(s) in binary (expected 3 on Linux).\n` +
+            `Salt found only ${saltCount} time(s) in binary (expected 3).\n` +
             '  This might work but the patch may be incomplete.\n' +
             `  Platform: ${platform()}`
           );

--- a/lib/tui.mjs
+++ b/lib/tui.mjs
@@ -128,7 +128,7 @@ export async function runApply({ silent = false } = {}) {
 
   // Check if already patched with our salt
   const check = verifySalt(binaryPath, config.salt);
-  if (check.found >= 3) {
+  if (check.found >= 1) {
     if (!silent) console.log(chalk.green('  Pet already applied.'));
     return;
   }
@@ -142,7 +142,7 @@ export async function runApply({ silent = false } = {}) {
     // Try to find the salt from our config's previous application
     if (config.previousSalt) {
       const prevCheck = verifySalt(binaryPath, config.previousSalt);
-      if (prevCheck.found >= 3) {
+      if (prevCheck.found >= 1) {
         const result = patchBinary(binaryPath, config.previousSalt, config.salt);
         if (!silent) {
           console.log(chalk.green(`  Re-patched (${result.replacements} replacements).`));
@@ -153,7 +153,7 @@ export async function runApply({ silent = false } = {}) {
     }
     // Try original salt as fallback (maybe Claude updated)
     const origCheck = verifySalt(binaryPath, ORIGINAL_SALT);
-    if (origCheck.found >= 3) {
+    if (origCheck.found >= 1) {
       const result = patchBinary(binaryPath, ORIGINAL_SALT, config.salt);
       if (!silent) {
         console.log(chalk.green(`  Patched after update (${result.replacements} replacements).`));
@@ -183,7 +183,7 @@ export async function runRestore() {
   if (config?.salt && config.salt !== ORIGINAL_SALT) {
     // Try to patch back to original
     const check = verifySalt(binaryPath, config.salt);
-    if (check.found >= 3) {
+    if (check.found >= 1) {
       const restoreResult = patchBinary(binaryPath, config.salt, ORIGINAL_SALT);
       console.log(chalk.green('  Restored original pet salt.'));
       warnCodesign(restoreResult, binaryPath);
@@ -340,7 +340,7 @@ export async function runInteractive(flags = {}) {
   } else if (existingConfig?.salt) {
     oldSalt = existingConfig.salt;
     const check = verifySalt(binaryPath, oldSalt);
-    if (check.found < 3) {
+    if (check.found < 1) {
       console.error(chalk.red('  Cannot find current salt in binary. Try restoring first.'));
       return;
     }


### PR DESCRIPTION
## Summary

- **Binary resolution**: On Windows, `where claude` returns the extensionless bash shim (`npm/claude`) not `claude.cmd`, so the existing `.cmd` handler never fires. Added fallback to try the `.cmd` sibling and parse it to find `cli.js`.
- **Platform candidate typo**: Fixed `cli.mjs` -> `cli.js` in the Windows fallback path list.
- **Salt thresholds**: The Windows JS bundle contains the salt string once (vs 3x in the Linux compiled binary). Lowered all occurrence thresholds from `>= 3` to `>= 1`. Kept the low-count warning for non-Windows platforms where 3 occurrences are expected.

## Reproduction

```
> any-buddy
Error: Salt "friend-2026-401" not found in C:\Users\...\npm\claude.cmd.
Platform: win32, binary: C:\Users\...\npm\claude.cmd
```

The tool was searching `claude.cmd` (347-byte shim) instead of `cli.js` (13MB JS bundle).

## Test plan

- [x] `findClaudeBinary()` resolves to `node_modules/@anthropic-ai/claude-code/cli.js`
- [x] `verifySalt()` finds 1 occurrence of the salt in `cli.js`
- [x] `getCurrentSalt()` correctly returns `patched: false` with 1 occurrence
- [x] `runPreflight()` passes with `ok: true`
- [x] `any-buddy current` displays the pet correctly
- [x] Non-Windows platforms still get a warning if salt count < 3

Tested on Windows 11 with Claude Code installed via `npm i -g @anthropic-ai/claude-code`.