### PR TITLE
fix: use FNV-1a hash for Node-based Claude installs (Windows npm)

### DIFF
--- a/lib/finder-worker.mjs
+++ b/lib/finder-worker.mjs
@@ -1,7 +1,15 @@
-#!/usr/bin/env bun
-// This script runs under Bun for fast native Bun.hash access.
+#!/usr/bin/env node
+// This script brute-forces salts to find a matching companion.
 // Called by finder.mjs as a subprocess.
-// Args: <userId> <species> <rarity> <eye> <hat> <shiny> <peak> <dump>
+// Runs under Bun (wyhash) by default, or Node (FNV-1a) when --fnv1a is passed.
+//
+// On Windows npm installs, Claude Code's cli.js runs under Node, not Bun.
+// The companion hash function has a runtime branch:
+//   if (typeof Bun !== "undefined") → Bun.hash (wyhash)
+//   else → FNV-1a
+// So we must use FNV-1a when searching for salts targeting Node-based installs.
+//
+// Args: <userId> <species> <rarity> <eye> <hat> <shiny> <peak> <dump> [--fnv1a]
 // Outputs JSON: { salt, attempts, elapsed }
 
 const RARITIES = ['common', 'uncommon', 'rare', 'epic', 'legendary'];
@@ -14,6 +22,23 @@ const SPECIES = [
 const EYES = ['·', '✦', '×', '◉', '@', '°'];
 const HATS = ['none', 'crown', 'tophat', 'propeller', 'halo', 'wizard', 'beanie', 'tinyduck'];
 const STAT_NAMES = ['DEBUGGING', 'PATIENCE', 'CHAOS', 'WISDOM', 'SNARK'];
+
+// Detect --fnv1a flag
+const useFnv1a = process.argv.includes('--fnv1a');
+
+function fnv1a(s) {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function hashKey(key) {
+  if (useFnv1a) return fnv1a(key);
+  return Number(BigInt(Bun.hash(key)) & 0xffffffffn);
+}
 
 function mulberry32(seed) {
   let a = seed >>> 0;
@@ -42,7 +67,7 @@ function rollRarity(rng) {
 
 function quickRoll(userId, salt, needStats) {
   const key = userId + salt;
-  const seed = Number(BigInt(Bun.hash(key)) & 0xffffffffn);
+  const seed = hashKey(key);
   const rng = mulberry32(seed);
   const rarity = rollRarity(rng);
   const species = pick(rng, SPECIES);
@@ -72,10 +97,12 @@ function randomSalt() {
   return s;
 }
 
-const [userId, wantSpecies, wantRarity, wantEye, wantHat, wantShiny, wantPeak, wantDump] = process.argv.slice(2);
+// Filter out --fnv1a from args
+const args = process.argv.slice(2).filter(a => a !== '--fnv1a');
+const [userId, wantSpecies, wantRarity, wantEye, wantHat, wantShiny, wantPeak, wantDump] = args;
 
 if (!userId || !wantSpecies || !wantRarity || !wantEye || !wantHat) {
-  console.error('Usage: finder-worker.mjs <userId> <species> <rarity> <eye> <hat> [shiny] [peak] [dump]');
+  console.error('Usage: finder-worker.mjs <userId> <species> <rarity> <eye> <hat> [shiny] [peak] [dump] [--fnv1a]');
   process.exit(1);
 }
 
@@ -88,10 +115,17 @@ const start = Date.now();
 let attempts = 0;
 
 try {
-  // Verify Bun.hash is available before entering the hot loop
-  if (typeof Bun === 'undefined' || typeof Bun.hash !== 'function') {
-    console.error(`Bun.hash is not available (typeof Bun: ${typeof Bun}). This worker must run under Bun, not Node.`);
+  // Verify hash function is available
+  if (!useFnv1a && (typeof Bun === 'undefined' || typeof Bun.hash !== 'function')) {
+    console.error(
+      `Bun.hash is not available (typeof Bun: ${typeof Bun}).\n` +
+      `This worker must run under Bun, or pass --fnv1a for Node-based Claude installs.`
+    );
     process.exit(1);
+  }
+
+  if (useFnv1a) {
+    process.stderr.write(JSON.stringify({ info: 'Using FNV-1a hash (Node runtime detected)' }) + '\n');
   }
 
   while (true) {

--- a/lib/finder.mjs
+++ b/lib/finder.mjs
@@ -2,7 +2,7 @@ import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { RARITY_WEIGHTS, diagnostics } from './constants.mjs';
-import { findBunBinary } from './patcher.mjs';
+import { findBunBinary, isNodeRuntime } from './patcher.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const WORKER_PATH = join(__dirname, 'finder-worker.mjs');
@@ -42,12 +42,16 @@ export function estimateAttempts(desired) {
   return Math.round(1 / p);
 }
 
-// Spawns a Bun subprocess that brute-forces salts using native Bun.hash.
+// Spawns a subprocess that brute-forces salts.
+// Uses Bun (wyhash) for compiled binary installs, or Node (FNV-1a) for npm .js installs.
 // Calls onProgress with { attempts, elapsed, rate, expected, pct, eta } on each tick.
 // Returns a promise resolving to { salt, attempts, elapsed }.
-export function findSalt(userId, desired, { onProgress } = {}) {
+export function findSalt(userId, desired, { onProgress, binaryPath } = {}) {
   const expected = estimateAttempts(desired);
-  const bunBinary = findBunBinary();
+
+  // Detect if the Claude binary is a .js file run by Node — if so, use FNV-1a
+  const useNodeHash = binaryPath ? isNodeRuntime(binaryPath) : false;
+  const runtime = useNodeHash ? process.execPath : findBunBinary();
 
   return new Promise((resolve, reject) => {
     const args = [
@@ -62,10 +66,15 @@ export function findSalt(userId, desired, { onProgress } = {}) {
       desired.dump ?? 'any',
     ];
 
+    // When targeting Node runtime, pass --fnv1a so the worker uses FNV-1a hash
+    if (useNodeHash) {
+      args.push('--fnv1a');
+    }
+
     // Scale timeout with expected attempts: 10 min base, +1 min per 50M attempts
     const timeout = Math.max(600000, Math.ceil(expected / 50_000_000) * 60_000 + 600_000);
 
-    const child = spawn(bunBinary, args, {
+    const child = spawn(runtime, args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout,
     });
@@ -86,6 +95,7 @@ export function findSalt(userId, desired, { onProgress } = {}) {
       for (const line of lines) {
         try {
           const progress = JSON.parse(line);
+          if (progress.info) return; // Skip info messages
           const rate = progress.attempts / (progress.elapsed / 1000); // attempts/sec
           const pct = Math.min(100, (progress.attempts / expected) * 100);
           // ETA based on expected remaining attempts at current rate
@@ -111,7 +121,7 @@ export function findSalt(userId, desired, { onProgress } = {}) {
           try { JSON.parse(l); return false; } catch { return true; }
         }).join('\n').trim();
         const extra = {
-          Bun: bunBinary,
+          Runtime: `${runtime} (${useNodeHash ? 'FNV-1a' : 'wyhash'})`,
           Expected: `~${expected.toLocaleString()} attempts`,
           Timeout: `${(timeout / 1000).toFixed(0)}s`,
           Args: `[${args.slice(1).map(a => `"${a}"`).join(', ')}]`,
@@ -123,7 +133,7 @@ export function findSalt(userId, desired, { onProgress } = {}) {
 
     child.on('error', (err) => {
       reject(new Error(
-        `Failed to spawn salt finder: ${err.message}\n\n${diagnostics({ Bun: bunBinary })}`
+        `Failed to spawn salt finder: ${err.message}\n\n${diagnostics({ Runtime: runtime })}`
       ));
     });
   });

--- a/lib/generation.mjs
+++ b/lib/generation.mjs
@@ -4,29 +4,45 @@ import {
 } from './constants.mjs';
 import { findBunBinary } from './patcher.mjs';
 
+// FNV-1a 32-bit hash — used when Claude Code runs under Node (e.g., Windows npm installs).
+function fnv1a(s) {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
 // Bun.hash (wyhash) — spawns bun to get the exact same hash Claude Code uses.
 // String passed via stdin since bun -e doesn't forward argv.
 // Cached to avoid repeated subprocess calls for the same input.
 const hashCache = new Map();
 
-export function hashString(s) {
-  if (hashCache.has(s)) return hashCache.get(s);
+// Hash a string using the same function Claude Code will use at runtime.
+// If useNodeHash is true, uses FNV-1a (for Node-based installs like Windows npm).
+// Otherwise, uses Bun.hash/wyhash (for compiled binary installs).
+export function hashString(s, { useNodeHash = false } = {}) {
+  const cacheKey = `${useNodeHash ? 'fnv' : 'bun'}:${s}`;
+  if (hashCache.has(cacheKey)) return hashCache.get(cacheKey);
+
+  if (useNodeHash) {
+    const result = fnv1a(s);
+    hashCache.set(cacheKey, result);
+    return result;
+  }
+
   try {
     const result = execFileSync(findBunBinary(), ['-e',
       'const s=await Bun.stdin.text();process.stdout.write(String(Number(BigInt(Bun.hash(s))&0xffffffffn)))',
     ], { encoding: 'utf-8', input: s, timeout: 5000 });
     const h = parseInt(result.trim(), 10);
-    hashCache.set(s, h);
+    hashCache.set(cacheKey, h);
     return h;
   } catch {
-    // Fallback to FNV-1a if bun isn't available (won't match Claude Code but works for testing)
-    let h = 2166136261;
-    for (let i = 0; i < s.length; i++) {
-      h ^= s.charCodeAt(i);
-      h = Math.imul(h, 16777619);
-    }
-    const result = h >>> 0;
-    hashCache.set(s, result);
+    // Fallback to FNV-1a if bun isn't available
+    const result = fnv1a(s);
+    hashCache.set(cacheKey, result);
     return result;
   }
 }
@@ -91,7 +107,8 @@ export function rollFrom(rng) {
 }
 
 // Roll with explicit salt param (unlike source which hardcodes it)
-export function roll(userId, salt) {
+// Pass useNodeHash: true for Node-based Claude installs (Windows npm)
+export function roll(userId, salt, { useNodeHash = false } = {}) {
   const key = userId + salt;
-  return rollFrom(mulberry32(hashString(key)));
+  return rollFrom(mulberry32(hashString(key, { useNodeHash })));
 }

--- a/lib/patcher.mjs
+++ b/lib/patcher.mjs
@@ -249,6 +249,13 @@ export function isClaudeRunning(binaryPath) {
   }
 }
 
+// Detect whether the Claude binary runs under Node (not Bun).
+// On Windows npm installs, the binary is a .js file executed by Node, which uses FNV-1a
+// instead of Bun.hash (wyhash). This changes the hash function used for companion generation.
+export function isNodeRuntime(binaryPath) {
+  return binaryPath.endsWith('.js') || binaryPath.endsWith('.mjs');
+}
+
 // Ad-hoc codesign on macOS (required after patching Mach-O binaries)
 function codesignBinary(binaryPath) {
   if (!IS_MAC) return { signed: false, error: null };

--- a/lib/preflight.mjs
+++ b/lib/preflight.mjs
@@ -3,7 +3,7 @@ import { execSync } from 'child_process';
 import { platform } from 'os';
 import chalk from 'chalk';
 import { ORIGINAL_SALT, ISSUE_URL, diagnostics } from './constants.mjs';
-import { findClaudeBinary, findBunBinary, verifySalt } from './patcher.mjs';
+import { findClaudeBinary, findBunBinary, verifySalt, isNodeRuntime } from './patcher.mjs';
 import { getClaudeUserId, loadPetConfig } from './config.mjs';
 
 // Run all preflight checks before doing anything destructive.
@@ -12,17 +12,14 @@ export function runPreflight({ requireBinary = true } = {}) {
   const errors = [];
   const warnings = [];
 
-  // ── 1. Check bun is installed ──
+  // ── 1. Check bun is installed (deferred — may not be needed for Node-based installs) ──
   let bunVersion = null;
+  let bunMissing = false;
   try {
     const bunPath = findBunBinary();
     bunVersion = execSync(`"${bunPath}" --version`, { encoding: 'utf-8', timeout: 5000 }).trim();
   } catch {
-    errors.push(
-      'Bun is not installed or not on PATH.\n' +
-      '  any-buddy needs Bun to compute the correct hash (Claude Code uses Bun.hash/wyhash).\n' +
-      '  Install Bun: https://bun.sh'
-    );
+    bunMissing = true;
   }
 
   // ── 2. Check Claude config exists and has a userId ──
@@ -127,6 +124,18 @@ export function runPreflight({ requireBinary = true } = {}) {
         );
       }
     }
+  }
+
+  // ── Bun requirement check ──
+  // Bun is only required when the Claude binary runs under Bun (compiled installs).
+  // For Node-based installs (e.g., Windows npm), FNV-1a is used instead and Bun is not needed.
+  const nodeRuntime = binaryPath ? isNodeRuntime(binaryPath) : false;
+  if (bunMissing && !nodeRuntime) {
+    errors.push(
+      'Bun is not installed or not on PATH.\n' +
+      '  any-buddy needs Bun to compute the correct hash (Claude Code uses Bun.hash/wyhash).\n' +
+      '  Install Bun: https://bun.sh'
+    );
   }
 
   // ── Print results ──

--- a/lib/tui.mjs
+++ b/lib/tui.mjs
@@ -5,7 +5,7 @@ import { SPECIES, EYES, HATS, RARITIES, RARITY_STARS, RARITY_WEIGHTS, STAT_NAMES
 import { roll } from './generation.mjs';
 import { renderSprite, renderFace } from './sprites.mjs';
 import { findSalt, estimateAttempts } from './finder.mjs';
-import { findClaudeBinary, getCurrentSalt, patchBinary, verifySalt, restoreBinary, isClaudeRunning } from './patcher.mjs';
+import { findClaudeBinary, getCurrentSalt, patchBinary, verifySalt, restoreBinary, isClaudeRunning, isNodeRuntime } from './patcher.mjs';
 import { runPreflight } from './preflight.mjs';
 import { getClaudeUserId, savePetConfig, loadPetConfig, isHookInstalled, installHook, removeHook, getCompanionName, renameCompanion, getCompanionPersonality, setCompanionPersonality, deleteCompanion } from './config.mjs';
 import { DEFAULT_PERSONALITIES } from './personalities.mjs';
@@ -85,14 +85,24 @@ export async function runCurrent() {
   const userId = preflight.userId;
   console.log(chalk.dim(`  User ID: ${userId.slice(0, 12)}...`));
 
+  // Detect if Claude runs under Node (Windows npm) — affects hash function
+  let useNodeHash = false;
+  try {
+    const bp = findClaudeBinary();
+    useNodeHash = isNodeRuntime(bp);
+  } catch { /* ignore — binary not required for current */ }
+  if (useNodeHash) {
+    console.log(chalk.dim('  Runtime: Node (FNV-1a hash)'));
+  }
+
   // Show what the original salt produces
-  const origResult = roll(userId, ORIGINAL_SALT);
+  const origResult = roll(userId, ORIGINAL_SALT, { useNodeHash });
   showPet(origResult.bones, 'Default pet (original salt)');
 
   // Show patched pet if applicable
   const config = loadPetConfig();
   if (config?.salt && config.salt !== ORIGINAL_SALT) {
-    const patchedResult = roll(userId, config.salt);
+    const patchedResult = roll(userId, config.salt, { useNodeHash });
     showPet(patchedResult.bones, 'Active pet (patched)');
   }
 }
@@ -257,19 +267,24 @@ export async function runInteractive(flags = {}) {
   const userId = preflight.userId;
   console.log(chalk.dim(`  User ID: ${userId.slice(0, 12)}...`));
   console.log(chalk.dim(`  Binary:  ${preflight.binaryPath} (salt found ${preflight.saltCount}x)`));
-  if (preflight.bunVersion) {
+
+  // Detect if Claude runs under Node (Windows npm) — affects hash function
+  const useNodeHash = isNodeRuntime(preflight.binaryPath);
+  if (useNodeHash) {
+    console.log(chalk.dim(`  Runtime: Node (using FNV-1a hash — npm install detected)`));
+  } else if (preflight.bunVersion) {
     console.log(chalk.dim(`  Bun:     v${preflight.bunVersion}`));
   }
   console.log();
 
   // Show current pet
-  const currentBones = roll(userId, ORIGINAL_SALT).bones;
+  const currentBones = roll(userId, ORIGINAL_SALT, { useNodeHash }).bones;
   showPet(currentBones, 'Your current default pet');
 
   // Check if already patched
   const existingConfig = loadPetConfig();
   if (existingConfig?.salt && existingConfig.salt !== ORIGINAL_SALT) {
-    const patchedBones = roll(userId, existingConfig.salt).bones;
+    const patchedBones = roll(userId, existingConfig.salt, { useNodeHash }).bones;
     showPet(patchedBones, 'Your active patched pet');
   }
 
@@ -316,6 +331,7 @@ export async function runInteractive(flags = {}) {
   console.log(chalk.dim(`\n  Searching (~${formatCount(expected)} expected attempts)...`));
 
   const result = await findSalt(userId, desired, {
+    binaryPath: preflight.binaryPath,
     onProgress: ({ attempts, elapsed, rate, pct, eta }) => {
       const bar = progressBar(pct, 20);
       const etaStr = eta < 1 ? '<1s' : eta < 60 ? `${Math.ceil(eta)}s` : `${(eta / 60).toFixed(1)}m`;
@@ -329,7 +345,7 @@ export async function runInteractive(flags = {}) {
   // Clear the progress line and show result
   process.stdout.write('\r' + ' '.repeat(80) + '\r');
   console.log(chalk.green(`  Found in ${result.attempts.toLocaleString()} attempts (${(result.elapsed / 1000).toFixed(1)}s)`));
-  const foundBones = roll(userId, result.salt).bones;
+  const foundBones = roll(userId, result.salt, { useNodeHash }).bones;
   showPet(foundBones, 'Your new pet');
 
   // ─── Patch binary (path already validated by preflight) ───


### PR DESCRIPTION
## Summary

- On Windows npm installs, Claude Code runs via `node cli.js` (not Bun). The companion hash function has a runtime branch — `Bun.hash` (wyhash) under Bun, FNV-1a under Node. The finder was always using `Bun.hash`, so salts it found produced the wrong pet when Claude actually ran under Node.
- This fix auto-detects `.js`/`.mjs` binaries as Node runtime and uses FNV-1a for salt brute-forcing
- Bun is no longer required for Node-based installs

## Changes

- `patcher.mjs`: Added `isNodeRuntime()` detection
- `finder-worker.mjs`: Added `--fnv1a` flag to use FNV-1a instead of `Bun.hash`
- `finder.mjs`: Detects Node runtime, passes `--fnv1a`, runs worker under Node instead of Bun
- `generation.mjs`: Added `useNodeHash` option to `hashString()` and `roll()`
- `preflight.mjs`: Bun check is now skipped for Node-based installs
- `tui.mjs`: Passes runtime detection through to finder and generation

## Test plan

- [x] Verified on Windows npm install (cli.js) — FNV-1a salt produces correct pet
- [x] `isNodeRuntime()` correctly identifies `.js` and `.mjs` files
- [x] `roll()` with `useNodeHash: true` matches Claude Code's actual output under Node
- [ ] Verify compiled binary installs (Linux/macOS) still use Bun.hash as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)