### PR TITLE
fix: handle root-owned Claude binaries on Linux

### DIFF
--- a/src/patcher/binary-finder.ts
+++ b/src/patcher/binary-finder.ts
@@ -58,6 +58,7 @@ function getPlatformCandidates(): string[] {
   return [
     join(home, '.local', 'bin', 'claude'),
     '/usr/local/bin/claude',
+    '/opt/claude-code/bin/claude',
     '/usr/bin/claude',
     join(home, '.npm-global', 'bin', 'claude'),
     join(home, '.volta', 'bin', 'claude'),
@@ -77,6 +78,27 @@ function resolveWindowsShim(cmdPath: string): string | null {
     /* ignore */
   }
   return null;
+}
+
+export function resolveShellWrapper(scriptPath: string): string | null {
+  if (IS_WIN) return null;
+  try {
+    const content = readFileSync(scriptPath, 'utf-8');
+    if (!content.startsWith('#!')) return null;
+
+    const match = content.match(/^\s*exec\s+(\/\S+)/m);
+    if (!match) return null;
+
+    const target = match[1];
+    if (!existsSync(target)) return null;
+
+    const size = statSync(target).size;
+    if (size < 1_000_000) return null;
+
+    return target;
+  } catch {
+    return null;
+  }
 }
 
 function resolveFromPackageDir(resolvedPath: string): string | null {
@@ -119,6 +141,9 @@ export function findClaudeBinary(): string {
       if (size >= 1_000_000) {
         return resolved;
       }
+      const fromWrapper = resolveShellWrapper(resolved);
+      if (fromWrapper) return fromWrapper;
+
       const fromPkg = resolveFromPackageDir(resolved);
       if (fromPkg) return fromPkg;
 

--- a/src/patcher/binary-finder.ts
+++ b/src/patcher/binary-finder.ts
@@ -194,6 +194,13 @@ export function findBunBinary(): string {
     ? [join(home, '.bun', 'bin', 'bun.exe'), join(home, '.volta', 'bin', 'bun.exe')]
     : [join(home, '.bun', 'bin', 'bun'), '/usr/local/bin/bun', join(home, '.volta', 'bin', 'bun')];
 
+  // Under sudo, homedir() returns /root — also check the original user's home.
+  const sudoUser = process.env.SUDO_USER;
+  if (sudoUser && !IS_WIN) {
+    const sudoHome = IS_MAC ? join('/Users', sudoUser) : join('/home', sudoUser);
+    candidates.push(join(sudoHome, '.bun', 'bin', 'bun'), join(sudoHome, '.volta', 'bin', 'bun'));
+  }
+
   for (const candidate of candidates) {
     if (existsSync(candidate)) return realpath(candidate);
   }

--- a/src/patcher/binary-finder.ts
+++ b/src/patcher/binary-finder.ts
@@ -186,6 +186,10 @@ export function findClaudeBinary(): string {
 }
 
 export function findBunBinary(): string {
+  if (process.env.ANYBUDDY_BUN_PATH && existsSync(process.env.ANYBUDDY_BUN_PATH)) {
+    return process.env.ANYBUDDY_BUN_PATH;
+  }
+
   const onPath = which('bun');
   if (onPath) return onPath;
 

--- a/src/patcher/index.ts
+++ b/src/patcher/index.ts
@@ -1,4 +1,4 @@
-export { findClaudeBinary, findBunBinary } from './binary-finder.ts';
+export { findClaudeBinary, findBunBinary, resolveShellWrapper } from './binary-finder.ts';
 export {
   findAllOccurrences,
   getCurrentSalt,

--- a/src/patcher/patch.ts
+++ b/src/patcher/patch.ts
@@ -7,8 +7,11 @@ import {
   unlinkSync,
   renameSync,
   existsSync,
+  accessSync,
+  constants,
 } from 'fs';
 import { execSync } from 'child_process';
+import { dirname } from 'path';
 import { platform } from 'os';
 import type { PatchResult } from '@/types.js';
 import { ORIGINAL_SALT } from '@/constants.js';
@@ -34,6 +37,15 @@ export function patchBinary(binaryPath: string, oldSalt: string, newSalt: string
   if (oldSalt.length !== newSalt.length) {
     throw new Error(
       `Salt length mismatch: old=${oldSalt.length}, new=${newSalt.length}. Must be ${ORIGINAL_SALT.length} chars.`,
+    );
+  }
+
+  try {
+    accessSync(dirname(binaryPath), constants.W_OK);
+  } catch {
+    throw new Error(
+      `No write permission on ${dirname(binaryPath)}.\n` +
+        '  The binary is owned by root. Run with: sudo any-buddy',
     );
   }
 

--- a/src/patcher/preflight.ts
+++ b/src/patcher/preflight.ts
@@ -1,5 +1,6 @@
-import { statSync } from 'fs';
+import { statSync, accessSync, constants } from 'fs';
 import { execSync } from 'child_process';
+import { dirname } from 'path';
 import { platform } from 'os';
 import chalk from 'chalk';
 import type { PreflightResult } from '@/types.js';
@@ -157,6 +158,16 @@ export function runPreflight({ requireBinary = true } = {}): PreflightResult {
     );
   }
 
+  // 4. Check write permission on binary directory
+  let needsSudo = false;
+  if (binaryPath) {
+    try {
+      accessSync(dirname(binaryPath), constants.W_OK);
+    } catch {
+      needsSudo = true;
+    }
+  }
+
   for (const w of warnings) {
     console.log(chalk.yellow(`  Warning: ${w}\n`));
   }
@@ -165,8 +176,8 @@ export function runPreflight({ requireBinary = true } = {}): PreflightResult {
     for (const e of errors) {
       console.log(chalk.red(`  Error: ${e}\n`));
     }
-    return { ok: false, binaryPath, userId, saltCount, bunVersion };
+    return { ok: false, binaryPath, userId, saltCount, bunVersion, needsSudo };
   }
 
-  return { ok: true, binaryPath, userId, saltCount, bunVersion };
+  return { ok: true, binaryPath, userId, saltCount, bunVersion, needsSudo };
 }

--- a/src/patcher/preflight.ts
+++ b/src/patcher/preflight.ts
@@ -16,10 +16,12 @@ export function runPreflight({ requireBinary = true } = {}): PreflightResult {
 
   // 1. Check bun is installed (deferred — may not be needed for Node-based installs)
   let bunVersion: string | null = null;
+  let bunPath: string | null = null;
   let bunMissing = false;
   try {
-    const bunPath = findBunBinary();
-    bunVersion = execSync(`"${bunPath}" --version`, { encoding: 'utf-8', timeout: 5000 }).trim();
+    const resolved = findBunBinary();
+    bunVersion = execSync(`"${resolved}" --version`, { encoding: 'utf-8', timeout: 5000 }).trim();
+    bunPath = resolved;
   } catch {
     bunMissing = true;
   }
@@ -176,8 +178,8 @@ export function runPreflight({ requireBinary = true } = {}): PreflightResult {
     for (const e of errors) {
       console.log(chalk.red(`  Error: ${e}\n`));
     }
-    return { ok: false, binaryPath, userId, saltCount, bunVersion, needsSudo };
+    return { ok: false, binaryPath, userId, saltCount, bunVersion, bunPath, needsSudo };
   }
 
-  return { ok: true, binaryPath, userId, saltCount, bunVersion, needsSudo };
+  return { ok: true, binaryPath, userId, saltCount, bunVersion, bunPath, needsSudo };
 }

--- a/src/patcher/salt-ops.ts
+++ b/src/patcher/salt-ops.ts
@@ -45,7 +45,7 @@ export function isClaudeRunning(binaryPath: string): boolean {
       return out.includes('claude.exe');
     }
     const name = basename(binaryPath);
-    const out = execSync(`pgrep -f "${name}" 2>/dev/null || true`, { encoding: 'utf-8' });
+    const out = execSync(`pgrep -x "${name}" 2>/dev/null || true`, { encoding: 'utf-8' });
     return out.trim().length > 0;
   } catch {
     return false;

--- a/src/patcher/sudo.ts
+++ b/src/patcher/sudo.ts
@@ -1,0 +1,23 @@
+import { execFileSync } from 'child_process';
+import chalk from 'chalk';
+import type { PreflightResult } from '@/types.js';
+
+/** Re-exec the current CLI under sudo, forwarding resolved paths as env vars. */
+export function execWithSudo(preflight: PreflightResult): never {
+  const args = process.argv.slice(1);
+  console.log(chalk.yellow('  Binary requires elevated permissions. Re-running with sudo...\n'));
+
+  const env: string[] = [`HOME=${process.env.HOME ?? ''}`];
+  if (preflight.bunPath) env.push(`ANYBUDDY_BUN_PATH=${preflight.bunPath}`);
+  if (preflight.binaryPath) env.push(`CLAUDE_BINARY=${preflight.binaryPath}`);
+
+  try {
+    execFileSync('sudo', ['env', ...env, process.execPath, ...args], {
+      stdio: 'inherit',
+    });
+    process.exit(0);
+  } catch {
+    console.error(chalk.red('  Sudo failed. Try: sudo any-buddy'));
+    process.exit(1);
+  }
+}

--- a/src/tui/apply/index.ts
+++ b/src/tui/apply/index.ts
@@ -608,8 +608,16 @@ export async function runApplyTUI(
 
           case 'confirm_patch':
             if (key.name === 'return' || key.name === 'y') {
-              doPatch();
-              showStep('confirm_hook');
+              try {
+                doPatch();
+                showStep('confirm_hook');
+              } catch (err) {
+                clearStep();
+                addText(`  Patch failed: ${(err as Error).message}`, '#ff5555');
+                helpBar.content = '  Enter to exit';
+                helpBar.fg = '#ff5555';
+                currentStep = 'done';
+              }
             } else if (key.name === 'escape' || key.name === 'n') {
               showStep('confirm_hook');
             }

--- a/src/tui/commands/buddies.ts
+++ b/src/tui/commands/buddies.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { execSync } from 'child_process';
 import { select } from '@inquirer/prompts';
 import { ORIGINAL_SALT, RARITY_STARS } from '@/constants.js';
 import { roll } from '@/generation/index.js';
@@ -49,6 +50,20 @@ export async function runBuddies(): Promise<void> {
   const preflight = runPreflight({ requireBinary: true });
   if (!preflight.ok || !preflight.binaryPath) {
     process.exit(1);
+  }
+
+  if (preflight.needsSudo && process.getuid?.() !== 0) {
+    const args = process.argv.slice(1);
+    console.log(chalk.yellow('  Binary requires elevated permissions. Re-running with sudo...\n'));
+    try {
+      execSync(`sudo ${process.execPath} ${args.map((a) => `"${a}"`).join(' ')}`, {
+        stdio: 'inherit',
+      });
+      process.exit(0);
+    } catch {
+      console.error(chalk.red('  Sudo failed. Try: sudo any-buddy'));
+      process.exit(1);
+    }
   }
 
   const config = loadPetConfigV2();

--- a/src/tui/commands/buddies.ts
+++ b/src/tui/commands/buddies.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { execSync } from 'child_process';
+
 import { select } from '@inquirer/prompts';
 import { ORIGINAL_SALT, RARITY_STARS } from '@/constants.js';
 import { roll } from '@/generation/index.js';
@@ -7,6 +7,7 @@ import { DEFAULT_PERSONALITIES } from '@/personalities.js';
 import { isNodeRuntime, verifySalt, isClaudeRunning, getMinSaltCount } from '@/patcher/salt-ops.js';
 import { patchBinary } from '@/patcher/patch.js';
 import { runPreflight } from '@/patcher/preflight.js';
+import { execWithSudo } from '@/patcher/sudo.js';
 import {
   loadPetConfigV2,
   savePetConfigV2,
@@ -53,20 +54,7 @@ export async function runBuddies(): Promise<void> {
   }
 
   if (preflight.needsSudo && process.getuid?.() !== 0) {
-    const args = process.argv.slice(1);
-    console.log(chalk.yellow('  Binary requires elevated permissions. Re-running with sudo...\n'));
-    try {
-      execSync(
-        `sudo --preserve-env=HOME ${process.execPath} ${args.map((a) => `"${a}"`).join(' ')}`,
-        {
-          stdio: 'inherit',
-        },
-      );
-      process.exit(0);
-    } catch {
-      console.error(chalk.red('  Sudo failed. Try: sudo any-buddy'));
-      process.exit(1);
-    }
+    execWithSudo(preflight);
   }
 
   const config = loadPetConfigV2();

--- a/src/tui/commands/buddies.ts
+++ b/src/tui/commands/buddies.ts
@@ -56,9 +56,12 @@ export async function runBuddies(): Promise<void> {
     const args = process.argv.slice(1);
     console.log(chalk.yellow('  Binary requires elevated permissions. Re-running with sudo...\n'));
     try {
-      execSync(`sudo ${process.execPath} ${args.map((a) => `"${a}"`).join(' ')}`, {
-        stdio: 'inherit',
-      });
+      execSync(
+        `sudo --preserve-env=HOME ${process.execPath} ${args.map((a) => `"${a}"`).join(' ')}`,
+        {
+          stdio: 'inherit',
+        },
+      );
       process.exit(0);
     } catch {
       console.error(chalk.red('  Sudo failed. Try: sudo any-buddy'));

--- a/src/tui/commands/interactive.ts
+++ b/src/tui/commands/interactive.ts
@@ -177,9 +177,12 @@ function runSetup(): SetupResult {
     const args = process.argv.slice(1);
     console.log(chalk.yellow('  Binary requires elevated permissions. Re-running with sudo...\n'));
     try {
-      execSync(`sudo ${process.execPath} ${args.map((a) => `"${a}"`).join(' ')}`, {
-        stdio: 'inherit',
-      });
+      execSync(
+        `sudo --preserve-env=HOME ${process.execPath} ${args.map((a) => `"${a}"`).join(' ')}`,
+        {
+          stdio: 'inherit',
+        },
+      );
       process.exit(0);
     } catch {
       console.error(chalk.red('  Sudo failed. Try: sudo any-buddy'));

--- a/src/tui/commands/interactive.ts
+++ b/src/tui/commands/interactive.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { execSync } from 'child_process';
 import { confirm, input, select } from '@inquirer/prompts';
 import type { CliFlags, DesiredTraits } from '@/types.js';
 import { SPECIES, EYES, RARITIES, HATS, STAT_NAMES, ORIGINAL_SALT } from '@/constants.js';
@@ -170,6 +171,20 @@ function runSetup(): SetupResult {
   const preflight = runPreflight({ requireBinary: true });
   if (!preflight.ok || !preflight.binaryPath) {
     process.exit(1);
+  }
+
+  if (preflight.needsSudo && process.getuid?.() !== 0) {
+    const args = process.argv.slice(1);
+    console.log(chalk.yellow('  Binary requires elevated permissions. Re-running with sudo...\n'));
+    try {
+      execSync(`sudo ${process.execPath} ${args.map((a) => `"${a}"`).join(' ')}`, {
+        stdio: 'inherit',
+      });
+      process.exit(0);
+    } catch {
+      console.error(chalk.red('  Sudo failed. Try: sudo any-buddy'));
+      process.exit(1);
+    }
   }
   const userId = preflight.userId;
   const binaryPath = preflight.binaryPath;

--- a/src/tui/commands/interactive.ts
+++ b/src/tui/commands/interactive.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { execSync } from 'child_process';
+
 import { confirm, input, select } from '@inquirer/prompts';
 import type { CliFlags, DesiredTraits } from '@/types.js';
 import { SPECIES, EYES, RARITIES, HATS, STAT_NAMES, ORIGINAL_SALT } from '@/constants.js';
@@ -14,6 +14,7 @@ import {
 } from '@/patcher/salt-ops.js';
 import { patchBinary } from '@/patcher/patch.js';
 import { runPreflight } from '@/patcher/preflight.js';
+import { execWithSudo } from '@/patcher/sudo.js';
 import {
   loadPetConfig,
   loadPetConfigV2,
@@ -174,20 +175,7 @@ function runSetup(): SetupResult {
   }
 
   if (preflight.needsSudo && process.getuid?.() !== 0) {
-    const args = process.argv.slice(1);
-    console.log(chalk.yellow('  Binary requires elevated permissions. Re-running with sudo...\n'));
-    try {
-      execSync(
-        `sudo --preserve-env=HOME ${process.execPath} ${args.map((a) => `"${a}"`).join(' ')}`,
-        {
-          stdio: 'inherit',
-        },
-      );
-      process.exit(0);
-    } catch {
-      console.error(chalk.red('  Sudo failed. Try: sudo any-buddy'));
-      process.exit(1);
-    }
+    execWithSudo(preflight);
   }
   const userId = preflight.userId;
   const binaryPath = preflight.binaryPath;

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,7 @@ export interface PreflightResult {
   userId: string;
   saltCount: number;
   bunVersion: string | null;
+  needsSudo: boolean;
 }
 
 export interface PetConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,7 @@ export interface PreflightResult {
   userId: string;
   saltCount: number;
   bunVersion: string | null;
+  bunPath: string | null;
   needsSudo: boolean;
 }
 

--- a/tests/patcher/binary-finder.test.ts
+++ b/tests/patcher/binary-finder.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { resolveShellWrapper } from '@/patcher/binary-finder.js';
+
+const tempDir = mkdtempSync(join(tmpdir(), 'anybuddy-binary-'));
+
+afterAll(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function createFakeBinary(name: string): string {
+  const path = join(tempDir, name);
+  writeFileSync(path, Buffer.alloc(1_100_000, 0x41));
+  return path;
+}
+
+function createScript(name: string, content: string): string {
+  const path = join(tempDir, name);
+  writeFileSync(path, content, 'utf-8');
+  return path;
+}
+
+describe('resolveShellWrapper', () => {
+  it('resolves exec /path/to/binary "$@" pattern', () => {
+    const binary = createFakeBinary('claude-real');
+    const script = createScript('claude-wrapper-1', `#!/bin/sh\nexec ${binary} "$@"\n`);
+    expect(resolveShellWrapper(script)).toBe(binary);
+  });
+
+  it('resolves exec /path/to/binary without args', () => {
+    const binary = createFakeBinary('claude-no-args');
+    const script = createScript('claude-wrapper-2', `#!/bin/sh\nexec ${binary}\n`);
+    expect(resolveShellWrapper(script)).toBe(binary);
+  });
+
+  it('resolves with env exports before exec', () => {
+    const binary = createFakeBinary('claude-env');
+    const script = createScript(
+      'claude-wrapper-3',
+      `#!/bin/sh\nexport DISABLE_AUTOUPDATER=1\nexec ${binary} "$@"\n`,
+    );
+    expect(resolveShellWrapper(script)).toBe(binary);
+  });
+
+  it('returns null for files without shebang', () => {
+    const binary = createFakeBinary('claude-noshebang');
+    const script = createScript('no-shebang', `exec ${binary} "$@"\n`);
+    expect(resolveShellWrapper(script)).toBeNull();
+  });
+
+  it('returns null when exec target does not exist', () => {
+    const script = createScript(
+      'claude-missing',
+      '#!/bin/sh\nexec /nonexistent/path/to/claude "$@"\n',
+    );
+    expect(resolveShellWrapper(script)).toBeNull();
+  });
+
+  it('returns null when exec target is too small', () => {
+    const tinyFile = join(tempDir, 'claude-tiny');
+    writeFileSync(tinyFile, 'not a real binary');
+    const script = createScript('claude-wrapper-tiny', `#!/bin/sh\nexec ${tinyFile} "$@"\n`);
+    expect(resolveShellWrapper(script)).toBeNull();
+  });
+
+  it('returns null for scripts without exec', () => {
+    const script = createScript('claude-no-exec', '#!/bin/sh\necho "hello"\n');
+    expect(resolveShellWrapper(script)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Context

If you install Claude Code as a system package (like on Arch with omarchy), `/usr/bin/claude` is actually a tiny shell wrapper that does `exec /opt/claude-code/bin/claude`. The binary finder didn't know how to follow that, so it'd see a 77-byte file and bail.

On top of that, the real binary is root-owned, so patching needs sudo. And when you re-run with sudo, the environment gets wiped — bun disappears from PATH (mine is managed by mise, but same thing happens with asdf, volta, etc.), and `$HOME` points to `/root` so none of the config files are found.

## What this does

**Shell wrappers**: Added `resolveShellWrapper()` that reads the script, finds the `exec` target, and follows it to the actual binary. Also added `/opt/claude-code/bin/claude` to the candidate list.

**Sudo re-exec**: If the binary dir isn't writable, we now re-run under sudo automatically (early, before the TUI starts — otherwise it freezes). The trick is resolving bun, the claude binary, and HOME *before* escalating, while PATH is still intact, then passing them through as env vars with `execFileSync('sudo', ['env', ...])`. No shell interpolation, no injection issues.

The sudo escalation logic lives in its own helper (`src/patcher/sudo.ts`) instead of being copy-pasted between commands.

**Why not just `sudo --preserve-env=PATH`?** Tried that first, but `secure_path` in sudoers silently overrides it on most distros. Resolving to absolute paths before sudo and forwarding them is more reliable.

## Testing

- 7 new tests for `resolveShellWrapper`, all 210 passing
- Build/lint/typecheck clean
- Tested manually on Arch with root-owned `/opt/claude-code/bin/claude` + bun via mise