### PR TITLE
fix: prefer native Claude binary over npm, prompt when multiple found

### DIFF
--- a/src/patcher/binary-finder.ts
+++ b/src/patcher/binary-finder.ts
@@ -7,7 +7,7 @@ import { ISSUE_URL, diagnostics } from '@/constants.js';
 const IS_WIN = platform() === 'win32';
 const IS_MAC = platform() === 'darwin';
 
-export const MIN_SUPPORTED_VERSION = '1.0.16';
+export const MIN_SUPPORTED_VERSION = '2.1.89';
 
 export interface ClaudeBinaryInfo {
   path: string;

--- a/src/patcher/binary-finder.ts
+++ b/src/patcher/binary-finder.ts
@@ -7,9 +7,18 @@ import { ISSUE_URL, diagnostics } from '@/constants.js';
 const IS_WIN = platform() === 'win32';
 const IS_MAC = platform() === 'darwin';
 
+export const MIN_SUPPORTED_VERSION = '1.0.16';
+
+export interface ClaudeBinaryInfo {
+  path: string;
+  version: string | null;
+  source: 'brew' | 'npm' | 'local' | 'volta' | 'system' | 'unknown';
+  supported: boolean;
+}
+
 function which(cmd: string): string | null {
   try {
-    const shellCmd = IS_WIN ? `where ${cmd}` : `which ${cmd}`;
+    const shellCmd = IS_WIN ? `where ${cmd}` : `which -a ${cmd}`;
     const result = execSync(shellCmd, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -20,6 +29,32 @@ function which(cmd: string): string | null {
     /* ignore */
   }
   return null;
+}
+
+function whichAll(cmd: string): string[] {
+  try {
+    const shellCmd = IS_WIN ? `where ${cmd}` : `which -a ${cmd}`;
+    const result = execSync(shellCmd, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    return result
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter((l) => l && existsSync(l));
+  } catch {
+    /* ignore */
+  }
+  return [];
+}
+
+function isNpmManagedPath(resolvedPath: string): boolean {
+  const lower = resolvedPath.toLowerCase();
+  return (
+    lower.includes('node_modules') ||
+    lower.includes('.npm-global') ||
+    lower.includes(join('npm', 'node_modules').toLowerCase())
+  );
 }
 
 function realpath(p: string): string {
@@ -98,6 +133,102 @@ function resolveFromPackageDir(resolvedPath: string): string | null {
   return null;
 }
 
+export function getClaudeVersion(binaryPath: string): string | null {
+  try {
+    const output = execSync(`"${binaryPath}" --version`, {
+      encoding: 'utf-8',
+      timeout: 10000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    // Output is like "2.1.92 (Claude Code)" — extract the version number
+    const match = output.match(/^([\d.]+)/);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const na = pa[i] ?? 0;
+    const nb = pb[i] ?? 0;
+    if (na !== nb) return na - nb;
+  }
+  return 0;
+}
+
+function classifySource(resolvedPath: string): ClaudeBinaryInfo['source'] {
+  const lower = resolvedPath.toLowerCase();
+  if (lower.includes('/homebrew/') || lower.includes('/brew/')) return 'brew';
+  if (isNpmManagedPath(resolvedPath)) return 'npm';
+  if (lower.includes('.volta')) return 'volta';
+  if (lower.includes('.local/bin') || lower.includes('.claude/local')) return 'local';
+  if (lower.includes('/usr/local/bin') || lower.includes('/usr/bin')) return 'system';
+  return 'unknown';
+}
+
+function resolveOneBinary(onPath: string): string | null {
+  const resolved = realpath(onPath);
+
+  if (IS_WIN && resolved.endsWith('.cmd')) {
+    const target = resolveWindowsShim(resolved);
+    if (target) return target;
+  }
+
+  try {
+    const size = statSync(resolved).size;
+    if (size >= 1_000_000) return resolved;
+
+    const fromPkg = resolveFromPackageDir(resolved);
+    if (fromPkg) return fromPkg;
+
+    if (IS_WIN && !resolved.endsWith('.cmd')) {
+      const target = resolveWindowsShim(resolved + '.cmd');
+      if (target) return target;
+    }
+  } catch {
+    return resolved;
+  }
+
+  return null;
+}
+
+export function findAllClaudeBinaries(): ClaudeBinaryInfo[] {
+  const seen = new Set<string>();
+  const results: ClaudeBinaryInfo[] = [];
+
+  function addCandidate(path: string) {
+    const resolved = realpath(path);
+    if (seen.has(resolved)) return;
+    seen.add(resolved);
+
+    const version = getClaudeVersion(resolved);
+    const source = classifySource(resolved);
+    const supported = version ? compareVersions(version, MIN_SUPPORTED_VERSION) >= 0 : false;
+    results.push({ path: resolved, version, source, supported });
+  }
+
+  // From PATH
+  const allOnPath = whichAll('claude');
+  for (const onPath of allOnPath) {
+    const resolved = resolveOneBinary(onPath);
+    if (resolved) addCandidate(resolved);
+  }
+
+  // From platform candidates
+  const candidates = getPlatformCandidates();
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      addCandidate(candidate);
+    }
+  }
+
+  return results;
+}
+
 export function findClaudeBinary(): string {
   if (process.env.CLAUDE_BINARY) {
     const p = process.env.CLAUDE_BINARY;
@@ -105,30 +236,66 @@ export function findClaudeBinary(): string {
     throw new Error(`CLAUDE_BINARY="${p}" does not exist.`);
   }
 
-  const onPath = which('claude');
-  if (onPath) {
+  const allOnPath = whichAll('claude');
+  let npmFallback: string | null = null;
+
+  for (const onPath of allOnPath) {
     const resolved = realpath(onPath);
 
     if (IS_WIN && resolved.endsWith('.cmd')) {
       const target = resolveWindowsShim(resolved);
-      if (target) return target;
+      if (target) {
+        if (isNpmManagedPath(target)) {
+          npmFallback = npmFallback ?? target;
+          continue;
+        }
+        return target;
+      }
     }
 
     try {
       const size = statSync(resolved).size;
       if (size >= 1_000_000) {
+        if (isNpmManagedPath(resolved)) {
+          npmFallback = npmFallback ?? resolved;
+          continue;
+        }
         return resolved;
       }
       const fromPkg = resolveFromPackageDir(resolved);
-      if (fromPkg) return fromPkg;
+      if (fromPkg) {
+        if (isNpmManagedPath(fromPkg)) {
+          npmFallback = npmFallback ?? fromPkg;
+          continue;
+        }
+        return fromPkg;
+      }
 
       if (IS_WIN && !resolved.endsWith('.cmd')) {
         const target = resolveWindowsShim(resolved + '.cmd');
-        if (target) return target;
+        if (target) {
+          if (isNpmManagedPath(target)) {
+            npmFallback = npmFallback ?? target;
+            continue;
+          }
+          return target;
+        }
       }
     } catch {
-      return resolved;
+      if (!isNpmManagedPath(resolved)) return resolved;
+      npmFallback = npmFallback ?? resolved;
     }
+  }
+
+  if (npmFallback) {
+    // Check platform candidates first — prefer native installs (e.g. Brew) over npm
+    const candidates = getPlatformCandidates();
+    for (const candidate of candidates) {
+      if (existsSync(candidate) && !isNpmManagedPath(candidate)) {
+        return realpath(candidate);
+      }
+    }
+    return npmFallback;
   }
 
   const candidates = getPlatformCandidates();

--- a/src/patcher/binary-finder.ts
+++ b/src/patcher/binary-finder.ts
@@ -53,7 +53,8 @@ function isNpmManagedPath(resolvedPath: string): boolean {
   return (
     lower.includes('node_modules') ||
     lower.includes('.npm-global') ||
-    lower.includes(join('npm', 'node_modules').toLowerCase())
+    lower.includes('.nvm/') ||
+    lower.includes('/fnm/')
   );
 }
 
@@ -137,7 +138,7 @@ export function getClaudeVersion(binaryPath: string): string | null {
   try {
     const output = execSync(`"${binaryPath}" --version`, {
       encoding: 'utf-8',
-      timeout: 10000,
+      timeout: 3000,
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
     // Output is like "2.1.92 (Claude Code)" — extract the version number
@@ -215,7 +216,8 @@ export function findAllClaudeBinaries(): ClaudeBinaryInfo[] {
   const allOnPath = whichAll('claude');
   for (const onPath of allOnPath) {
     const resolved = resolveOneBinary(onPath);
-    if (resolved) addCandidate(resolved);
+    // Fall back to the raw path if resolveOneBinary couldn't find a large binary
+    addCandidate(resolved ?? realpath(onPath));
   }
 
   // From platform candidates

--- a/src/patcher/preflight.ts
+++ b/src/patcher/preflight.ts
@@ -4,12 +4,20 @@ import { platform } from 'os';
 import chalk from 'chalk';
 import type { PreflightResult } from '@/types.js';
 import { ORIGINAL_SALT, ISSUE_URL, diagnostics } from '@/constants.js';
-import { findClaudeBinary, findBunBinary } from './binary-finder.ts';
+import {
+  findClaudeBinary,
+  findBunBinary,
+  findAllClaudeBinaries,
+  MIN_SUPPORTED_VERSION,
+} from './binary-finder.ts';
 import { restoreBinary } from './patch.ts';
 import { verifySalt, isNodeRuntime, getMinSaltCount } from './salt-ops.ts';
 import { getClaudeUserId, loadPetConfig } from '@/config/index.js';
 
-export function runPreflight({ requireBinary = true } = {}): PreflightResult {
+export async function runPreflight({
+  requireBinary = true,
+  silent = false,
+} = {}): Promise<PreflightResult> {
   const errors: string[] = [];
   const warnings: string[] = [];
 
@@ -38,10 +46,64 @@ export function runPreflight({ requireBinary = true } = {}): PreflightResult {
   let saltCount = 0;
 
   if (requireBinary) {
-    try {
-      binaryPath = findClaudeBinary();
-    } catch (err) {
-      errors.push((err as Error).message);
+    // Check for multiple installations and prompt user to select
+    if (!process.env.CLAUDE_BINARY && !silent) {
+      const allBinaries = findAllClaudeBinaries();
+      if (allBinaries.length > 1) {
+        const supported = allBinaries.filter((b) => b.supported);
+        const unsupported = allBinaries.filter((b) => !b.supported);
+
+        console.log(chalk.yellow(`\n  Found ${allBinaries.length} Claude Code installation(s):\n`));
+
+        for (const b of allBinaries) {
+          const ver = b.version ? `v${b.version}` : 'unknown version';
+          const src = b.source.charAt(0).toUpperCase() + b.source.slice(1);
+          if (b.supported) {
+            console.log(chalk.green(`    ${src} ${ver}  ${chalk.dim(b.path)}`));
+          } else {
+            console.log(
+              chalk.red(
+                `    ${src} ${ver}  ${chalk.dim(b.path)}  (requires v${MIN_SUPPORTED_VERSION}+)`,
+              ),
+            );
+          }
+        }
+        console.log();
+
+        if (supported.length === 0) {
+          errors.push(
+            `All ${allBinaries.length} Claude Code installations are too old.\n` +
+              `  any-buddy requires Claude Code v${MIN_SUPPORTED_VERSION} or newer.\n` +
+              '  Please update Claude Code and try again.',
+          );
+        } else if (supported.length === 1) {
+          binaryPath = supported[0].path;
+          if (unsupported.length > 0) {
+            console.log(
+              chalk.dim(
+                `  Auto-selected the only supported installation (${supported[0].source} v${supported[0].version}).`,
+              ),
+            );
+            console.log(chalk.dim(`  Tip: Remove old installations to avoid confusion.\n`));
+          }
+        } else {
+          try {
+            const { selectClaudeBinary } = await import('@/tui/prompts.js');
+            binaryPath = await selectClaudeBinary(allBinaries);
+          } catch {
+            // Prompt failed (non-interactive) — fall back to auto-selection
+            binaryPath = findClaudeBinary();
+          }
+        }
+      }
+    }
+
+    if (!binaryPath) {
+      try {
+        binaryPath = findClaudeBinary();
+      } catch (err) {
+        errors.push((err as Error).message);
+      }
     }
 
     if (binaryPath) {

--- a/src/tui/commands/buddies.ts
+++ b/src/tui/commands/buddies.ts
@@ -48,7 +48,7 @@ async function selectBuddyFallback(entries: GalleryEntry[]): Promise<string | nu
 export async function runBuddies(): Promise<void> {
   banner();
 
-  const preflight = runPreflight({ requireBinary: true });
+  const preflight = await runPreflight({ requireBinary: true });
   if (!preflight.ok || !preflight.binaryPath) {
     process.exit(1);
   }

--- a/src/tui/commands/current.ts
+++ b/src/tui/commands/current.ts
@@ -9,7 +9,7 @@ import { banner, showPet } from '../display.ts';
 
 export async function runCurrent(): Promise<void> {
   banner();
-  const preflight = runPreflight({ requireBinary: false });
+  const preflight = await runPreflight({ requireBinary: false });
   if (!preflight.ok) process.exit(1);
   const userId = preflight.userId;
   console.log(chalk.dim(`  User ID: ${userId.slice(0, 12)}...`));

--- a/src/tui/commands/interactive.ts
+++ b/src/tui/commands/interactive.ts
@@ -166,8 +166,8 @@ interface SetupResult {
   useNodeHash: boolean;
 }
 
-function runSetup(): SetupResult {
-  const preflight = runPreflight({ requireBinary: true });
+async function runSetup(): Promise<SetupResult> {
+  const preflight = await runPreflight({ requireBinary: true });
   if (!preflight.ok || !preflight.binaryPath) {
     process.exit(1);
   }
@@ -202,7 +202,7 @@ export async function runInteractive(
 ): Promise<void> {
   if (!skipBanner) banner();
 
-  const { userId, binaryPath, useNodeHash } = runSetup();
+  const { userId, binaryPath, useNodeHash } = await runSetup();
 
   let desired: DesiredTraits;
   try {
@@ -222,7 +222,7 @@ export async function runInteractiveWithTraits(
   desired: DesiredTraits,
   flags: CliFlags = {},
 ): Promise<void> {
-  const { userId, binaryPath, useNodeHash } = runSetup();
+  const { userId, binaryPath, useNodeHash } = await runSetup();
   await applyDesiredTraits(desired, flags, { userId, binaryPath, useNodeHash });
 }
 

--- a/src/tui/commands/preview.ts
+++ b/src/tui/commands/preview.ts
@@ -73,7 +73,7 @@ export async function runPreview(flags: CliFlags = {}): Promise<void> {
     return;
   }
 
-  const preflight = runPreflight({ requireBinary: false });
+  const preflight = await runPreflight({ requireBinary: false });
   if (!preflight.ok) process.exit(1);
 
   if (allTraitsFlagged(flags)) {

--- a/src/tui/commands/share.ts
+++ b/src/tui/commands/share.ts
@@ -78,7 +78,7 @@ function copyToClipboard(text: string): boolean {
 }
 
 export async function runShare(): Promise<void> {
-  const preflight = runPreflight({ requireBinary: false });
+  const preflight = await runPreflight({ requireBinary: false });
   if (!preflight.ok) process.exit(1);
 
   const userId = preflight.userId;

--- a/src/tui/prompts.ts
+++ b/src/tui/prompts.ts
@@ -13,6 +13,7 @@ import { renderSprite, renderFace } from '@/sprites/index.js';
 import { PRESETS, type Preset } from '@/presets.js';
 import { RARITY_CHALK } from './format.ts';
 import chalk from 'chalk';
+import type { ClaudeBinaryInfo } from '@/patcher/binary-finder.js';
 
 export function validateFlag<T extends string>(
   name: string,
@@ -157,5 +158,41 @@ export async function selectPreset(): Promise<Preset> {
       };
     }),
     pageSize: 12,
+  });
+}
+
+const SOURCE_LABELS: Record<ClaudeBinaryInfo['source'], string> = {
+  brew: 'Homebrew',
+  npm: 'npm',
+  local: 'Local install',
+  volta: 'Volta',
+  system: 'System',
+  unknown: 'Unknown',
+};
+
+export async function selectClaudeBinary(binaries: ClaudeBinaryInfo[]): Promise<string> {
+  const supported = binaries.filter((b) => b.supported);
+  const unsupported = binaries.filter((b) => !b.supported);
+
+  const choices = [
+    ...supported.map((b) => ({
+      name: `${chalk.green(SOURCE_LABELS[b.source])}  v${b.version}  ${chalk.dim(b.path)}`,
+      value: b.path,
+    })),
+    ...unsupported.map((b) => ({
+      name:
+        chalk.strikethrough(
+          chalk.dim(
+            `${SOURCE_LABELS[b.source]}  ${b.version ? `v${b.version}` : 'unknown version'}  ${b.path}`,
+          ),
+        ) + chalk.red('  (unsupported — update to use any-buddy)'),
+      value: b.path,
+      disabled: true as const,
+    })),
+  ];
+
+  return select({
+    message: 'Multiple Claude Code installations found — which one should any-buddy patch?',
+    choices,
   });
 }

--- a/src/tui/prompts.ts
+++ b/src/tui/prompts.ts
@@ -174,6 +174,10 @@ export async function selectClaudeBinary(binaries: ClaudeBinaryInfo[]): Promise<
   const supported = binaries.filter((b) => b.supported);
   const unsupported = binaries.filter((b) => !b.supported);
 
+  if (supported.length === 0) {
+    throw new Error('No supported Claude Code installation found.');
+  }
+
   const choices = [
     ...supported.map((b) => ({
       name: `${chalk.green(SOURCE_LABELS[b.source])}  v${b.version}  ${chalk.dim(b.path)}`,
@@ -194,5 +198,6 @@ export async function selectClaudeBinary(binaries: ClaudeBinaryInfo[]): Promise<
   return select({
     message: 'Multiple Claude Code installations found — which one should any-buddy patch?',
     choices,
+    loop: false,
   });
 }


### PR DESCRIPTION
## Summary

- When both npm-installed and native (Brew/local) Claude Code binaries exist, the tool now prefers native installs instead of whichever appears first in `PATH`
- When multiple supported binaries are detected, users are prompted to select which one to patch
- Binaries with versions older than the minimum supported are shown as disabled/unselectable with a clear message to update
- Adds `findAllClaudeBinaries()`, `getClaudeVersion()`, `compareVersions()`, and source classification helpers

## Problem

Users who have both an older npm-installed Claude Code and a newer Brew-installed version would get the npm one silently targeted, because `which claude` returns whichever is first in `PATH`. This caused patching failures or patching the wrong binary (see #35).

## Changes

- **`binary-finder.ts`**: Uses `which -a` to discover all binaries. Iterates all PATH results, skipping npm-managed paths in favor of native installs. Adds `findAllClaudeBinaries()` for full discovery with version/source metadata.
- **`preflight.ts`**: Now async. When multiple installations are found, lists them with version info and either auto-selects (if only one supported) or prompts the user. Silent mode skips the prompt.
- **`prompts.ts`**: New `selectClaudeBinary()` prompt — supported binaries are selectable, unsupported ones are shown as disabled with strikethrough styling.
- **Caller updates**: All `runPreflight()` callers updated to `await` the now-async function.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` — all 203 tests pass
- [x] `npm run build` succeeds
- [ ] Manual test: install Claude via both npm and brew, verify prompt appears
- [ ] Manual test: verify `CLAUDE_BINARY` env var still overrides everything
- [ ] Manual test: verify `--silent` mode skips the prompt

Fixes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)