### PR TITLE
docs: update /buddy references to /hatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ any-buddy preview            # Browse without applying
 any-buddy apply              # Re-apply after Claude Code update
 any-buddy restore            # Restore original pet
 any-buddy buddies            # Browse and switch between your buddies
-any-buddy rehatch            # Delete companion, re-hatch via /buddy
+any-buddy rehatch            # Delete companion, re-hatch via /hatch
 ```
 
 ### Non-Interactive Mode

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -141,7 +141,7 @@ Usage:
   any-buddy apply [--silent]         Re-apply saved pet after update
   any-buddy restore                  Restore original pet
   any-buddy buddies                  Browse and switch between your buddies
-  any-buddy rehatch                  Delete companion to re-hatch via /buddy
+  any-buddy rehatch                  Delete companion to re-hatch via /hatch
 
 Options:
   --preset <name>        Use a curated preset (e.g., "Arcane Dragon", "Royal Capybara")

--- a/src/config/claude-config.ts
+++ b/src/config/claude-config.ts
@@ -51,7 +51,7 @@ export function renameCompanion(newName: string): void {
     throw new Error(`Failed to parse Claude config at ${configPath}`);
   }
   if (!config.companion) {
-    throw new Error('No companion found in config. Run /buddy in Claude Code first to hatch one.');
+    throw new Error('No companion found in config. Run /hatch in Claude Code first to hatch one.');
   }
   config.companion.name = newName;
   writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', { mode: 0o600 });
@@ -81,7 +81,7 @@ export function setCompanionPersonality(personality: string): void {
     throw new Error(`Failed to parse Claude config at ${configPath}`);
   }
   if (!config.companion) {
-    throw new Error('No companion found in config. Run /buddy in Claude Code first to hatch one.');
+    throw new Error('No companion found in config. Run /hatch in Claude Code first to hatch one.');
   }
   config.companion.personality = personality;
   writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', { mode: 0o600 });

--- a/src/tui/apply/index.ts
+++ b/src/tui/apply/index.ts
@@ -389,10 +389,10 @@ export async function runApplyTUI(
             addSpacer();
             if (running) {
               addText('  Done! Quit all Claude Code sessions and relaunch.', RARITY_HEX.legendary);
-              addText('  Then run /buddy to meet your new companion.', DIM_COLOR);
+              addText('  Then run /hatch to meet your new companion.', DIM_COLOR);
             } else {
               addText(
-                '  Done! Launch Claude Code and run /buddy to see your new pet.',
+                '  Done! Launch Claude Code and run /hatch to see your new pet.',
                 RARITY_HEX.uncommon,
               );
             }

--- a/src/tui/commands/interactive.ts
+++ b/src/tui/commands/interactive.ts
@@ -486,7 +486,7 @@ async function applyDesiredTraitsSequential(
     console.log(chalk.dim('\n  No companion hatched yet — the visual patch has been applied.'));
     console.log(
       chalk.dim(
-        '  Run /buddy in Claude Code to hatch your companion and get a name & personality.',
+        '  Run /hatch in Claude Code to hatch your companion and get a name & personality.',
       ),
     );
     console.log(chalk.dim('  Then run any-buddy again to customize the name and personality.'));
@@ -511,10 +511,10 @@ async function applyDesiredTraitsSequential(
         '\n  Done! Quit all Claude Code sessions and relaunch to see your new pet.',
       ),
     );
-    console.log(chalk.dim('  Then run /buddy to meet your new companion.'));
+    console.log(chalk.dim('  Then run /hatch to meet your new companion.'));
   } else {
     console.log(
-      chalk.bold.green('\n  Done! Launch Claude Code and run /buddy to see your new pet.'),
+      chalk.bold.green('\n  Done! Launch Claude Code and run /hatch to see your new pet.'),
     );
   }
   console.log(

--- a/src/tui/commands/rehatch.ts
+++ b/src/tui/commands/rehatch.ts
@@ -20,7 +20,7 @@ export async function runRehatch(): Promise<void> {
   console.log();
 
   const proceed = await confirm({
-    message: `Delete "${name}" so Claude Code generates a fresh companion on next /buddy?`,
+    message: `Delete "${name}" so Claude Code generates a fresh companion on next /hatch?`,
     default: false,
   });
 
@@ -31,5 +31,5 @@ export async function runRehatch(): Promise<void> {
 
   deleteCompanion();
   console.log(chalk.green(`\n  Companion "${name}" deleted.`));
-  console.log(chalk.dim('  Run /buddy in Claude Code to hatch a new one.\n'));
+  console.log(chalk.dim('  Run /hatch in Claude Code to hatch a new one.\n'));
 }


### PR DESCRIPTION
Help text, error messages, and post-apply instructions referenced /buddy; the current Claude Code companion command is /hatch. Pure string substitution, no logic changes.